### PR TITLE
Remove logic that always declare the source table and model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules/

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ transient failures by automatic reprocessing and incrementally updating the outp
 
 ## Quick Start Guide
 ### Installation
-Add the bqml package to your package.json file in your Dataform project. 
-You can find the most up to date package version on the releases page.
+Add the bqml package to your package.json file in your Dataform project.
+
+```javascript
+{
+  "dependencies": {
+    "bqml": "https://github.com/dataform-co/dataform-bqml/archive/[RELEASE_VERSION].tar.gz"
+  }
+}
+```
+You can find the most up to date package version on the [releases](https://github.com/dataform-co/dataform-bqml/releases) page.
 
 ### Usage
 The following example shows how to generate text from images using the
@@ -27,6 +35,11 @@ let source_table = "product_image";
 // Name of the table for storing the result
 let output_table = "product_image_description";
 
+// Optionally declare the model and source table as dataform datasources 
+// if it is not defined in other actions.
+declare({name: model});
+declare({name: source_table});
+
 // Execute the pipeline
 bqml.vision_generate_text(
     source_table, output_table, model, 
@@ -41,7 +54,7 @@ bqml.vision_generate_text(
 #### Signature
 ```javascript
 function generate_text(
-    source_table, output_table, unique_keys,
+    output_table, unique_keys,
     ml_model, source_query, ml_configs, options)
 ```
 #### Description
@@ -51,7 +64,6 @@ Performs the ML.GENERATE_TEXT function on the given source table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| source_table | <code>Resolvable</code> | represents the source table |
 | output_table | <code>String</code> | the name of the table to store the final result |
 | unique_keys | <code>String</code> \| <code>Array</code> | column name(s) for identifying an unique row in the source table |
 | ml_model | <code>Resolvable</code> | the remote model to use for the ML operation that uses one of the Vertex AI LLM endpoints |
@@ -85,8 +97,8 @@ Performs the ML.GENERATE_TEXT function on visual content in the given source tab
 #### Signature
 ```javascript
 function generate_embedding(
-    source_table, output_table, unique_keys,
-    ml_model, source_query, ml_configs, options = {})
+    output_table, unique_keys,
+    ml_model, source_query, ml_configs, options)
 ```
 #### Description
 Performs the ML.GENERATE_EMBEDDING function on the given source table.
@@ -95,7 +107,6 @@ Performs the ML.GENERATE_EMBEDDING function on the given source table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| source_table | <code>Resolvable</code> | represents the source table |
 | output_table | <code>String</code> | the name of the table to store the final result |
 | unique_keys | <code>String</code> \| <code>Array</code> | column name(s) for identifying an unique row in the source table |
 | ml_model | <code>Resolvable</code> | the remote model to use for the ML operation that uses one of the `textembedding-gecko*` Vertex AI LLMs as endpoint |
@@ -108,7 +119,7 @@ Performs the ML.GENERATE_EMBEDDING function on the given source table.
 #### Signature
 ```javascript
 function understand_text(
-    source_table, output_table, unique_keys,
+    output_table, unique_keys,
     ml_model, source_query, ml_configs, options)
 ```
 #### Description
@@ -118,7 +129,6 @@ Performs the ML.UNDERSTAND_TEXT function on the given source table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| source_table | <code>Resolvable</code> | represents the source table |
 | output_table | <code>String</code> | the name of the table to store the final result |
 | unique_keys | <code>String</code> \| <code>Array</code> | column name(s) for identifying an unique row in the source table |
 | ml_model | <code>Resolvable</code> | the remote model with a REMOTE_SERVICE_TYPE of CLOUD_AI_NATURAL_LANGUAGE_V1 |
@@ -131,7 +141,7 @@ Performs the ML.UNDERSTAND_TEXT function on the given source table.
 #### Signature
 ```javascript
 function translate(
-    source_table, output_table, unique_keys,
+    output_table, unique_keys,
     ml_model, source_query, ml_configs, options)
 ```
 #### Description
@@ -141,7 +151,6 @@ Performs the ML.TRANSLATE function on the given source table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| source_table | <code>Resolvable</code> | represents the source table |
 | output_table | <code>String</code> | the name of the table to store the final result |
 | unique_keys | <code>String</code> \| <code>Array</code> | column name(s) for identifying an unique row in the source table |
 | ml_model | <code>Resolvable</code> | the remote model with a REMOTE_SERVICE_TYPE of CLOUD_AI_TRANSLATE_V3 |

--- a/modules/structured_table_ml.js
+++ b/modules/structured_table_ml.js
@@ -1,29 +1,29 @@
-const common = require("./utils.js");
+const common = require("./utils");
 
 /**
  * A generic structured table ML pipeline.
- * It incrementally performs an ML operation on rows from the source table 
- * and merges to the output table until all rows are processed or runs longer 
+ * It incrementally performs an ML operation on rows from the source table
+ * and merges to the output table until all rows are processed or runs longer
  * than the specific duration.
- * 
+ *
  * @param {String} output_table name of the output table
  * @param {String | Array} unique_keys column name(s) for identifying an unique row in the source table
  * @param {String} ml_function the name of the BQML function to call
  * @param {Resolvable} ml_model the remote model to use for the ML operation
- * @param {String | Function} source_query either a query string or a Contextable function to produce the 
- *                            query on the source data for the ML operation and it must have the unique key 
+ * @param {String | Function} source_query either a query string or a Contextable function to produce the
+ *                            query on the source data for the ML operation and it must have the unique key
  *                            columns selected in addition to other fields
  * @param {String} accept_filter a SQL boolean expression for accepting a row to the output table after
  *                 the ML operation
  * @param {Object} ml_configs configurations for the ML operation
- * @param {Number} batch_size number of rows to process in each SQL job. Rows in the object table will be 
+ * @param {Number} batch_size number of rows to process in each SQL job. Rows in the object table will be
  *                 processed in batches according to the batch size. Default batch size is 10000
- * @param {Number} batch_duration_secs the number of seconds to pass before breaking the batching loop if it 
+ * @param {Number} batch_duration_secs the number of seconds to pass before breaking the batching loop if it
  *                 hasn't been finished before within this duration. Default value is 22 hours
  */
 function table_ml(output_table, unique_keys, ml_function, ml_model, source_query, accept_filter, ml_configs = {}, {
     batch_size = 10000,
-    batch_duration_secs = 22 * 60 * 60
+    batch_duration_secs = 22 * 60 * 60,
 } = {}) {
     let source_func = (source_query instanceof Function) ? source_query : () => source_query;
     let limit_clause = `LIMIT ${batch_size}`;
@@ -35,7 +35,7 @@ function table_ml(output_table, unique_keys, ml_function, ml_model, source_query
     operate(`init_${output_table}`)
         .queries((ctx) => `CREATE TABLE IF NOT EXISTS ${ctx.resolve(output_table)} AS 
             SELECT * FROM ${ml_function} (
-                MODEL ${ctx.resolve(ml_model)},
+                MODEL ${ctx.ref(ml_model)},
                 (SELECT * FROM (${source_func(ctx)}) ${limit_clause}),
                 STRUCT (${ml_configs_string})
             ) WHERE ${accept_filter}`);
@@ -52,7 +52,7 @@ function table_ml(output_table, unique_keys, ml_function, ml_model, source_query
         REPEAT --;`)}`);
     table.query((ctx) => `
         SELECT * FROM ${ml_function} (
-            MODEL ${ctx.resolve(ml_model)},
+            MODEL ${ctx.ref(ml_model)},
             (SELECT S.* FROM (${source_func(ctx)}) AS S
                 ${ctx.when(ctx.incremental(), 
                 `WHERE NOT EXISTS (SELECT * FROM ${ctx.resolve(output_table)} AS T WHERE ${unique_keys.map((k) => `S.${k} = T.${k}`).join(' AND ')})`)} ${limit_clause}),
@@ -61,98 +61,82 @@ function table_ml(output_table, unique_keys, ml_function, ml_model, source_query
     table.postOps((ctx) => `${ctx.when(ctx.incremental(), `
         UNTIL (SELECT @@row_count) = 0 OR TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), @@script.creation_time, SECOND) >= ${batch_duration_secs}
         END REPEAT`, ``)}`);
-};
+}
 
 /**
  * Performs the ML.GENERATE_EMBEDDING function on the given source table.
- * 
- * @param {Resolvable} source_table represents the source table
+ *
  * @param {String} output_table the name of the table to store the final result
  * @param {String | Array} unique_keys column name(s) for identifying an unique row in the source table
- * @param {Resolvable} ml_model the remote model to use for the ML operation that uses one of the 
+ * @param {Resolvable} ml_model the remote model to use for the ML operation that uses one of the
  *                     `textembedding-gecko*` Vertex AI LLMs as endpoint
- * @param {String | Function} source_query either a query string or a Contextable function to produce the 
- *                            query on the source data for the ML operation and it must have the unique key 
+ * @param {String | Function} source_query either a query string or a Contextable function to produce the
+ *                            query on the source data for the ML operation and it must have the unique key
  *                            columns selected in addition to other fields
  * @param {Object} ml_configs configurations for the ML operation
  * @param {Object} options the configuration object for the {@link table_ml} function
- * 
+ *
  * @see {@link https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-embedding}
  */
-function generate_embedding(source_table, output_table, unique_keys, ml_model, source_query, ml_configs, options) {
-    common.declare_resolvable(source_table);
-    common.declare_resolvable(ml_model);
-
+function generate_embedding(output_table, unique_keys, ml_model, source_query, ml_configs, options) {
     table_ml(output_table, unique_keys, "ML.GENERATE_EMBEDDING", ml_model, source_query,
         common.retryable_error_filter("ml_generate_embedding_status"), ml_configs, options);
-};
+}
 
 /**
  * Performs the ML.GENERATE_TEXT function on the given source table.
- * 
- * @param {Resolvable} source_table represents the source table
+ *
  * @param {String} output_table the name of the table to store the final result
  * @param {String | Array} unique_keys column name(s) for identifying an unique row in the source table
- * @param {Resolvable} ml_model the remote model to use for the ML operation that uses one 
+ * @param {Resolvable} ml_model the remote model to use for the ML operation that uses one
  *                     of the Vertex AI LLM endpoints
- * @param {String | Function} source_query either a query string or a Contextable function to produce the 
- *                            query on the source data for the ML operation and it must have the unique key 
+ * @param {String | Function} source_query either a query string or a Contextable function to produce the
+ *                            query on the source data for the ML operation and it must have the unique key
  *                            columns selected in addition to other fields
  * @param {Object} ml_configs configurations for the ML operation
  * @param {Object} options the configuration object for the {@link table_ml} function
- * 
+ *
  * @see {@link https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-text}
  */
-function generate_text(source_table, output_table, unique_keys, ml_model, source_query, ml_configs, options) {
-    common.declare_resolvable(source_table);
-    common.declare_resolvable(ml_model);
-
+function generate_text(output_table, unique_keys, ml_model, source_query, ml_configs, options) {
     table_ml(output_table, unique_keys, "ML.GENERATE_TEXT", ml_model, source_query,
         common.retryable_error_filter("ml_generate_text_status"), ml_configs, options);
 }
 
 /**
  * Performs the ML.UNDERSTAND_TEXT function on the given source table.
- * 
- * @param {Resolvable} source_table represents the source table
+ *
  * @param {String} output_table the name of the table to store the final result
  * @param {String | Array} unique_keys column name(s) for identifying an unique row in the source table
  * @param {Resolvable} ml_model the remote model with a REMOTE_SERVICE_TYPE of CLOUD_AI_NATURAL_LANGUAGE_V1
- * @param {String | Function} source_query either a query string or a Contextable function to produce the 
- *                            query on the source data for the ML operation and it must have the unique key 
+ * @param {String | Function} source_query either a query string or a Contextable function to produce the
+ *                            query on the source data for the ML operation and it must have the unique key
  *                            columns selected in addition to other fields
  * @param {Object} ml_configs configurations for the ML operation
  * @param {Object} options the configuration object for the {@link table_ml} function
- * 
+ *
  * @see {@link https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-understand-text}
  */
-function understand_text(source_table, output_table, unique_keys, ml_model, source_query, ml_configs, options) {
-    common.declare_resolvable(source_table);
-    common.declare_resolvable(ml_model);
-
+function understand_text(output_table, unique_keys, ml_model, source_query, ml_configs, options) {
     table_ml(output_table, unique_keys, "ML.UNDERSTAND_TEXT", ml_model, source_query,
         common.retryable_error_filter("ml_understand_text_status"), ml_configs, options);
 }
 
 /**
  * Performs the ML.TRANSLATE function on the given source table.
- * 
- * @param {Resolvable} source_table represents the source table
+ *
  * @param {String} output_table the name of the table to store the final result
  * @param {String | Array} unique_keys column name(s) for identifying an unique row in the source table
  * @param {Resolvable} ml_model the remote model with a REMOTE_SERVICE_TYPE of CLOUD_AI_TRANSLATE_V3
- * @param {String | Function} source_query either a query string or a Contextable function to produce the 
- *                            query on the source data for the ML operation and it must have the unique key 
+ * @param {String | Function} source_query either a query string or a Contextable function to produce the
+ *                            query on the source data for the ML operation and it must have the unique key
  *                            columns selected in addition to other fields
  * @param {Object} ml_configs configurations for the ML operation
  * @param {Object} options the configuration object for the {@link table_ml} function
- * 
+ *
  * @see {@link https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-translate}
  */
-function translate(source_table, output_table, unique_keys, ml_model, source_query, ml_configs, options) {
-    common.declare_resolvable(source_table);
-    common.declare_resolvable(ml_model);
-
+function translate(output_table, unique_keys, ml_model, source_query, ml_configs, options) {
     table_ml(output_table, unique_keys, "ML.TRANSLATE", ml_model, source_query,
         common.retryable_error_filter("ml_translate_status"), ml_configs, options);
 }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,22 +1,19 @@
-module.exports = {
-    /**
-     * Declares the resolvable as a Dataform data source.
-     */
-    declare_resolvable: (source) => {
-        if (source.constructor === Object) {
-            declare(source);
-        } else {
-            declare({
-                name: source
-            });
-        }
-    },
+/**
+ * Declares the resolvable as a Dataform data source.
+ */
+function declare_resolvable(resolvable) {
+    return declare(resolvable.constructor === Object ? resolvable :{ name : resolvable});
+}
 
-    /**
-     * Forms a SQL filter clause for filtering out retryable 
-     * error based on a given status column.
-     */
-    retryable_error_filter: (status_col) => {
-        return `${status_col} NOT LIKE 'A retryable error occurred:%'`;
-    },
+/**
+ * Forms a SQL filter clause for filtering out retryable
+ * error based on a given status column.
+ */
+function retryable_error_filter(status_col) {
+    return `${status_col} NOT LIKE 'A retryable error occurred:%'`;
+}
+
+module.exports = {
+    declare_resolvable,
+    retryable_error_filter,
 };


### PR DESCRIPTION
- It is a backward incompabile change. Signatures for functions in the structured_table_ml.js are changed.
- Use context.ref instead of context.resolve for referencing source table and model.